### PR TITLE
Add command execution error feedback

### DIFF
--- a/src/main/kotlin/xyz/cssxsh/mirai/diffusion/StableDiffusionListener.kt
+++ b/src/main/kotlin/xyz/cssxsh/mirai/diffusion/StableDiffusionListener.kt
@@ -93,7 +93,7 @@ public object StableDiffusionListener : SimpleListenerHost() {
         val sd = client
         val out = dataFolder
 
-        launch {
+        commandLaunch {
 
             subject.sendMessage(At(sender) + "\n 正在努力绘画，请稍等.")
 
@@ -199,7 +199,7 @@ public object StableDiffusionListener : SimpleListenerHost() {
         val sd = client
         val out = dataFolder
 
-        launch {
+        commandLaunch {
 
             subject.sendMessage(At(sender) + "\n 正在执行图生图，请稍等.")
 
@@ -444,4 +444,25 @@ public object StableDiffusionListener : SimpleListenerHost() {
             }
         }
     }
+
+    private fun launchByCatching(
+        block: suspend CoroutineScope.() -> Unit,
+        transform: suspend (Throwable) -> Unit
+    ) = launch {
+        runCatching {
+            block(this)
+        }.recoverCatching {
+            transform(it)
+        }
+    }
+
+    private fun MessageEvent.commandLaunch(
+        block: suspend CoroutineScope.() -> Unit
+    ) {
+        launchByCatching(block = block, transform = {
+            subject.sendMessage("在执行指令的过程中发生了额外的错误: \n$it")
+            logger.error(it)
+        })
+    }
+
 }


### PR DESCRIPTION
### Content

When **an error occurs during the operation** of an instruction, the error is **captured** and **fed back** to the user

When an error occurs, the process **is not** terminated directly, **send error message** to the user then stop

- support for txt2img
- support for img2img

### Preview of the effect

Take error `java.net.ConnectException: Failed to connect` as an example

![image](https://user-images.githubusercontent.com/99005149/230719275-a7537d2f-14a8-49f1-aa22-a30865009cdd.png)

Mirai-console log content

```text
2023-04-08 19:28:35 V/Bot.botId: Group(groupId) <- 在执行指令的过程中发生了额外的错误: \njava.net.ConnectException: Failed to connect to /127.0.0.1:7860
2023-04-08 19:28:35 E/StableDiffusionListener: java.net.ConnectException: Failed to connect to /127.0.0.1:7860
java.net.ConnectException: Failed to connect to /127.0.0.1:7860
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:297)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:207)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:106)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.net.ConnectException: Connection refused: no further information
	at java.base/sun.nio.ch.Net.pollConnect(Native Method)
	at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:672)
	at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:542)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:597)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:633)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.platform.Platform.connectSocket(Platform.kt:128)
	at stable-diffusion-helper-0.5.0.mirai2.jar[private]//okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:295)
	... 18 more
```
